### PR TITLE
Expect gen fix

### DIFF
--- a/lib/rules/expect-gen-run.js
+++ b/lib/rules/expect-gen-run.js
@@ -10,8 +10,13 @@ module.exports = {
 	  return;
 	}
 
+	let expressionStatementNode = node.parent;
+	while (expressionStatementNode.type !== 'ExpressionStatement') {
+	  expressionStatementNode = expressionStatementNode.parent;
+	}
+
 	const SourceCode = context.getSourceCode();
-	const text = SourceCode.getText();
+	const text = SourceCode.getText(expressionStatementNode);
 
 	const didRun = text.includes('.run()');
 	const didJson = text.includes('.toJSON()');

--- a/lib/rules/expect-gen-run.test.js
+++ b/lib/rules/expect-gen-run.test.js
@@ -39,5 +39,21 @@ ruleTester.run("expect-gen-run", rule, {
       type: 'Identifier',
     }],
     parserOptions,
+  }, {
+    code: 
+      `expectGen(effect)
+        .next()
+	.run();
+
+       expectGen(effect)
+	.next();
+      `,
+    errors: [{
+      message: 'Must run expectGen',
+      line: 4,
+      column: 1,
+      type: 'Identifier',
+    }],
+    parserOptions,
   }]
 });

--- a/lib/rules/expect-gen-run.test.js
+++ b/lib/rules/expect-gen-run.test.js
@@ -50,8 +50,8 @@ ruleTester.run("expect-gen-run", rule, {
       `,
     errors: [{
       message: 'Must run expectGen',
-      line: 4,
-      column: 1,
+      line: 5,
+      column: 8,
       type: 'Identifier',
     }],
     parserOptions,


### PR DESCRIPTION
We can't just use the global source code, because then we have false positives. We find `expectGen` and then look for the whole expression statement node, like `expectGen(effect).next()`. We use this to determine if we are calling `run()` or `toJSON()`